### PR TITLE
Fix zsh pattern expansion error in devtree remove function

### DIFF
--- a/zsh/lib/devtree.zsh
+++ b/zsh/lib/devtree.zsh
@@ -536,7 +536,7 @@ _devtree_remove() {
     if [[ -n "$branch_name" ]] && [[ "$force" != true ]]; then
         # Check if branch exists in other worktrees or remotes
         local branch_refs
-        branch_refs=$(git for-each-ref --format='%(refname)' refs/heads/"$branch_name" refs/remotes/*/"$branch_name" 2>/dev/null | wc -l)
+        branch_refs=$(git for-each-ref --format='%(refname)' refs/heads/"$branch_name" refs/remotes 2>/dev/null | grep -c "/$branch_name$" || echo 0)
         
         if [[ "$branch_refs" -eq 1 ]]; then
             read "response?Delete the branch '$branch_name' as well? [y/N]: "

--- a/zsh/lib/devtree.zsh
+++ b/zsh/lib/devtree.zsh
@@ -536,7 +536,7 @@ _devtree_remove() {
     if [[ -n "$branch_name" ]] && [[ "$force" != true ]]; then
         # Check if branch exists in other worktrees or remotes
         local branch_refs
-        branch_refs=$(git for-each-ref --format='%(refname)' refs/heads/"$branch_name" refs/remotes 2>/dev/null | grep -c "/$branch_name$" || echo 0)
+        branch_refs=$(git for-each-ref --format='%(refname)' --glob="refs/heads/$branch_name" --glob="refs/remotes/*/$branch_name" 2>/dev/null | wc -l)
         
         if [[ "$branch_refs" -eq 1 ]]; then
             read "response?Delete the branch '$branch_name' as well? [y/N]: "


### PR DESCRIPTION
Resolves the error "_devtree_remove:117: no matches found: refs/remotes/*/feature-devtree" by replacing wildcard pattern with explicit refs/remotes search and grep filtering.

🤖 Generated with [Claude Code](https://claude.ai/code)